### PR TITLE
Ability to reset database

### DIFF
--- a/RZDataManager/RZCoreDataManager.h
+++ b/RZDataManager/RZCoreDataManager.h
@@ -29,6 +29,7 @@
  *
  ************************************************************************************/
 
+OBJC_EXTERN NSString * const kRZCoreDataManagerWillResetDatabaseNotification;
 OBJC_EXTERN NSString * const kRZCoreDataManagerDidResetDatabaseNotification;
 
 @class RZDataImporter;

--- a/RZDataManager/RZCoreDataManager.m
+++ b/RZDataManager/RZCoreDataManager.m
@@ -12,6 +12,7 @@
 // For storing moc reference in thread dictionary
 static NSString* const kRZCoreDataManagerConfinedMocKey = @"RZCoreDataManagerConfinedMoc";
 
+NSString * const kRZCoreDataManagerWillResetDatabaseNotification = @"RZCoreDataManagerWillResetDatabase";
 NSString * const kRZCoreDataManagerDidResetDatabaseNotification = @"RZCoreDataManagerDidResetDatabase";
 
 @interface RZCoreDataManager ()
@@ -706,6 +707,8 @@ NSString * const kRZCoreDataManagerDidResetDatabaseNotification = @"RZCoreDataMa
 
 - (void)resetDatabase
 {
+    [[NSNotificationCenter defaultCenter] postNotificationName:kRZCoreDataManagerWillResetDatabaseNotification object:self];
+    
     self.backgroundMoc = nil;
     self.managedObjectContext = nil;
     self.persistentStoreCoordinator = nil;


### PR DESCRIPTION
The safety of this is of course, completely implementation-specific. But provided nothing is going to try to write to the database, all should be good.

Also, the database stack is retained all the way up the chain (moc retains parent retains PSC) so even if there is a leftover reference to the main MOC, and pending operations (in theory) should not crash if they are performed after the reset, but I think an error will be raised when trying to save to disk...
